### PR TITLE
lower minimum declared go version to match requirement

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/dmachard/go-clientsyslog
 
-go 1.23
+go 1.16


### PR DESCRIPTION
This resolves #4

I found the minimum version by using [mingo](https://github.com/bobg/mingo), and running it as `mingo -tests -v .`.  This pointed out that the minimum required version is 1.16 because of the `os.ReadFile` usage [here](https://github.com/dmachard/go-clientsyslog/blob/main/clientsyslog.go#L59).